### PR TITLE
Duplicate annotation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Throw an error when a policy has duplicate members on a resource 
+
 # v3.0.3
 * Allow annotations to be set on a policy resource.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v3.0.4
 * Throw an error when a policy has duplicate members on a resource 
 
 # v3.0.3

--- a/lib/conjur-policy-parser-version.rb
+++ b/lib/conjur-policy-parser-version.rb
@@ -2,6 +2,6 @@
 
 module Conjur
   module PolicyParser
-    VERSION = "3.0.3"
+    VERSION = "3.0.4"
   end
 end

--- a/lib/conjur/policy/yaml/handler.rb
+++ b/lib/conjur/policy/yaml/handler.rb
@@ -202,7 +202,7 @@ module Conjur
           
           def initialize parent, anchor, type
             super parent, anchor
-            
+            @existing_members = Set.new()
             @record = type.new
           end
   
@@ -229,6 +229,11 @@ module Conjur
   
           # Begins a new map entry.
           def scalar value, tag, quoted, anchor
+            if @existing_members.include?(value)
+              raise "Duplicate attribute: #{value}"
+            else
+              @existing_members.add(value);
+            end
             value = scalar_value(value, tag, quoted, type)
             MapEntry.new(self, anchor, @record, value).tap do |h|
               h.push_handler

--- a/spec/resolver-fixtures/invalid-duplicate-annotation-error.yml
+++ b/spec/resolver-fixtures/invalid-duplicate-annotation-error.yml
@@ -1,0 +1,8 @@
+policy: |
+  - !host
+    id: test-app
+    annotations:
+      description: value1
+      description: value2
+
+error: "Error at line 4, column 16 in  : Duplicate attribute: description"

--- a/spec/resolver-fixtures/invalid-duplicate-member-error.yml
+++ b/spec/resolver-fixtures/invalid-duplicate-member-error.yml
@@ -1,0 +1,18 @@
+policy: |
+  - !host host1
+  - !host host2
+
+  - !variable secret
+  - !group secret-consumers
+
+  - !permit
+    role: !group secret-consumers
+    resource: !variable secret
+    privilege: [ read, execute ]
+
+  - !grant
+    role: !group secret-consumers
+    member: !host host1
+    member: !host host2
+
+error: "Error at line 14, column 9 in  : Duplicate attribute: member"


### PR DESCRIPTION
This PR is cherry-picked from https://github.com/cyberark/conjur-policy-parser/pull/16
#### What does this PR do? Is there any background context you want to provide?
This PR ensures an upload of a policy fails when there are duplicates in any of its mappings. Such as having duplicate annotations within a resource
#### What ticket does this PR close?
[cyberark/conjur#1263](https://github.com/cyberark/conjur/issues/1263) and [cyberark/conjur#1262](https://github.com/cyberark/conjur/issues/1262)
#### Where should the reviewer start? How should this functionality be validated?
handler.rb 

#### Next steps
Ensure the appliance uses this updated version