### PR TITLE
22 add types to relativepathresolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Allow the usage of relative paths on revoke and deny policies.
+
 # v3.0.4
 * Throw an error when a policy has duplicate members on a resource 
 

--- a/lib/conjur/policy/resolver.rb
+++ b/lib/conjur/policy/resolver.rb
@@ -131,15 +131,16 @@ module Conjur
     #
     # A Relative path is allowed only on:
     #
-    # * The +member+ of a Grant
-    # * The +role+ of a Permit.
+    # * The +member+ of a Grant and Revoke
+    # * The +role+ of a Permit and Deny.
     # * Any +owner+.
     # * Any annotation value.
     class RelativePathResolver < PolicyTraversal
       def resolve_record record, visited
         resolve_owner record if record.respond_to?(:owner)
-        resolve_grant record if record.is_a?(Types::Grant)
-        resolve_permit record if record.is_a?(Types::Permit)
+        resolve_grant_member record if record.is_a?(Types::Grant)
+        resolve_revoke_member record if record.is_a?(Types::Revoke)
+        resolve_role record if resolve_role? record
         resolve_annotations record if record.respond_to?(:annotations)
 
         super
@@ -149,13 +150,23 @@ module Conjur
         record.owner.id = absolute_path_of(record.owner.id) if record.owner && record.owner.id
       end
 
-      def resolve_grant record
+      # Members in grant policies have an associated role, and this method
+      # resolves the associated role's id
+      def resolve_grant_member record
         Array(record.member).each do |member|
           member.role.id = absolute_path_of(member.role.id)
         end
       end
 
-      def resolve_permit record
+      # Members in revoke policies are roles, and this method
+      # resolves their ID
+      def resolve_revoke_member record
+        Array(record.member).each do |member|
+          member.id = absolute_path_of(member.id)
+        end
+      end
+
+      def resolve_role record
         Array(record.role).each do |role|
           role.id = absolute_path_of(role.id)
         end
@@ -168,6 +179,10 @@ module Conjur
             annotations[k] = absolute_path_of([record.id, v].join('/'))
           end
         end
+      end
+
+      def resolve_role? record
+        record.is_a?(Types::Permit) || record.is_a?(Types::Deny)
       end
 
       # Resolve paths starting with '/' as an absolute path by stripping the leading character.

--- a/spec/resolver-fixtures/relative-path.yml
+++ b/spec/resolver-fixtures/relative-path.yml
@@ -2,7 +2,9 @@
 policy: |
   # Relative paths don't get any special handling in record creation
   - !group ../invalid-group
+
   - !group the-group
+
   - !policy
     id: myapp
     body:
@@ -12,11 +14,19 @@ policy: |
     - !group ../the-third-group
 
     - !variable
+    
     - !permit
       # Permit 'role' is expanded as a relative path
       role: ../the-group
       privilege: [ read, execute ]
       resource: !variable
+
+    - !deny
+      # deny 'role' is expanded as a relative path
+      role: ../the-group
+      privilege: [ read, execute ]
+      resource: !variable
+
     - !permit
       role: ../the-group
       privilege: [ read, execute ]
@@ -31,6 +41,11 @@ policy: |
     - !grant
       role: the-group
       # Grant 'member' is expanded as a relative path
+      member: !group ../the-group
+
+    - !revoke
+      role: the-group
+      # Revoke 'member' is expanded as a relative path
       member: !group ../the-group
 
 expectation: |
@@ -94,6 +109,16 @@ expectation: |
     role: !role
       account: the-account
       id: the-group
+  - !deny
+    privilege:
+    - read
+    - execute
+    resource: !variable
+      account: the-account
+      id: myapp
+    role: !role
+      account: the-account
+      id: the-group
   - !permit
     privilege:
     - read
@@ -117,6 +142,13 @@ expectation: |
       role: !group
         account: the-account
         id: the-group
+    role: !role
+      account: the-account
+      id: myapp/the-group
+  - !revoke
+    member: !member
+      account: the-account
+      id: the-group
     role: !role
       account: the-account
       id: myapp/the-group


### PR DESCRIPTION
Issue: https://github.com/cyberark/conjur-policy-parser/issues/22

I was unsure regarding the relative paths for members in `revoke` and `grant` statements. It seems that members either have a `role.id` or an `id`. So currently, I transform both of those into relative paths.  (Not sure if that was the right decision)

The next step is to bump the version!