### PR TITLE
Add coverage archive to Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,9 +36,10 @@ pipeline {
       steps {
         sh './test.sh'
         junit 'spec/reports/*.xml'
+        cobertura coberturaReportFile: 'coverage/coverage.xml'
       }
     }
-    
+
     // Only publish to RubyGems if branch is 'master'
     // AND someone confirms this stage within 5 minutes
     stage('Publish to RubyGems?') {
@@ -77,9 +78,9 @@ pipeline {
         sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd'
         deleteDir()
       }
-    }    
+    }
   }
-  
+
   post {
     always {
       cleanupAndNotify(currentBuild.currentResult)

--- a/conjur-policy-parser.gemspec
+++ b/conjur-policy-parser.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-expectations"
   spec.add_development_dependency "ci_reporter_rspec"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov-cobertura"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "deepsort"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 require 'simplecov'
+require 'simplecov-cobertura'
+
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 SimpleCov.start do
   add_filter '/spec/'
   add_filter '/features/'
@@ -10,7 +13,7 @@ require 'conjur-policy-parser'
 require 'logger'
 
 if ENV['DEBUG']
-  Conjur::PolicyParser::YAML::Handler.logger.level = Logger::DEBUG 
+  Conjur::PolicyParser::YAML::Handler.logger.level = Logger::DEBUG
 end
 
 require 'sorted_yaml.rb'


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>
This repo was already measuring code coverage, but it only showed up in the Jenkins console log. This PR adds archiving the coverage for the 2.5 test run (all 3 test runs are currently the same, so I just archived the latest) in the Jenkins build results. 