### PR TITLE
Add type validation for CIDR values in `restricted_to`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 * Allow the usage of relative paths on revoke and deny policies.
+* Return validation error when `restricted_to` values are not correct CIDR
+  notated IP addresses or ranges.
+  [cyberark/conjur-policy-parser#27](https://github.com/cyberark/conjur-policy-parser/issues/27)
 
 # v3.0.4
 * Throw an error when a policy has duplicate members on a resource 
@@ -22,5 +25,4 @@
 # v2.2.0
 
 * Add deletion statements `delete`, `deny`, and `revoke`.
-
 

--- a/lib/conjur/policy/types/base.rb
+++ b/lib/conjur/policy/types/base.rb
@@ -121,6 +121,21 @@ module Conjur
             String
         end
 
+        # +value+ must be a CIDR.
+        def expect_cidr name, value
+          # A CIDR value is valid if it can be parsed as an IPAddr object
+          validate_cidr = lambda do
+            IPAddr.new(value)
+          rescue IPAddr::Error
+            raise "Invalid IP address or CIDR range '#{value}'"
+          end
+
+          expect_type name,
+            value,
+            "CIDR",
+            validate_cidr
+        end
+
         # +value+ must be a Integer.
         def expect_integer name, value
           expect_type name,

--- a/lib/conjur/policy/types/records.rb
+++ b/lib/conjur/policy/types/records.rb
@@ -147,7 +147,7 @@ module Conjur
 
         attribute :uidnumber, kind: :integer, singular: true, dsl_accessor: true
         attribute :public_key, kind: :string, dsl_accessor: true
-        attribute :restricted_to, kind: :string, dsl_accessor: true
+        attribute :restricted_to, kind: :cidr, dsl_accessor: true
 
         def id_attribute; 'login'; end
         
@@ -171,7 +171,7 @@ module Conjur
         include ActsAsResource
         include ActsAsRole
 
-        attribute :restricted_to, kind: :string, dsl_accessor: true
+        attribute :restricted_to, kind: :cidr, dsl_accessor: true
 
         def custom_attribute_names
           [ :restricted_to ]

--- a/spec/errors/yaml/invalid-cidr-in-array.yml
+++ b/spec/errors/yaml/invalid-cidr-in-array.yml
@@ -1,0 +1,5 @@
+# 4, 46
+# Invalid IP address or CIDR range 'invalid_cidr'
+- !host
+  id: a-host
+  restricted_to: [ 192.168.1.1, invalid_cidr ]

--- a/spec/errors/yaml/invalid-cidr.yml
+++ b/spec/errors/yaml/invalid-cidr.yml
@@ -1,0 +1,5 @@
+# 5, 0
+# Invalid IP address or CIDR range 'invalid_cidr'
+- !host
+  id: a-host
+  restricted_to: invalid_cidr

--- a/spec/errors/yaml/multiple-invalid-cidr-in-array.yml
+++ b/spec/errors/yaml/multiple-invalid-cidr-in-array.yml
@@ -1,0 +1,5 @@
+# 4, 60
+# Invalid IP address or CIDR range 'first_invalid_cidr'
+- !host
+  id: a-host
+  restricted_to: [ first_invalid_cidr, second_invalid_cidr ]

--- a/spec/yaml_loader_spec.rb
+++ b/spec/yaml_loader_spec.rb
@@ -49,4 +49,7 @@ describe Conjur::PolicyParser::YAML::Loader do
   it_should_behave_like 'error message', 'incorrect-type-for-field-2'
   it_should_behave_like 'error message', 'incorrect-type-for-array-field'
   it_should_behave_like 'error message', 'no-such-attribute'
+  it_should_behave_like 'error message', 'invalid-cidr'
+  it_should_behave_like 'error message', 'invalid-cidr-in-array'
+  it_should_behave_like 'error message', 'multiple-invalid-cidr-in-array'
 end


### PR DESCRIPTION
This PR updates the type for `restricted_to` to a new `:cidr` type, that is validated at policy load to ensure this is a valid `IPAddr` string. If it is not valid, it returns a correct error to point the author to the line and column of the invalid value.

For example, with the policy:
```
- !host
  id: a-host
  restricted_to: [ 192.168.1.1, invalid_cidr ]
```

This will cause a validation error:
```
Error at line 3, column 32 in spec/round-trip/yaml/restricted_to.yml : Invalid IP address or CIDR range 'invalid_cidr'
```

Connected to #27 